### PR TITLE
Detect latest version

### DIFF
--- a/scripts/lib/validation/matched-registry.sh
+++ b/scripts/lib/validation/matched-registry.sh
@@ -1,16 +1,5 @@
 #!/bin/sh
 
-package_id_digits=${PACKAGE_ID//./ }
-domain_name=""
-matched_registry=""
-for digit in ${package_id_digits[@]}
-do
-  domain_name="${domain_name}.${digit}"
-  domain_name=$(echo ${domain_name} | sed -e 's/^\.//')
-  matched_registry=$(cat ${manifest_file} | jq ".scopedRegistries[] | select(.scopes[] == \"${domain_name}\")")
-  [[ -n "${matched_registry}" ]] && break
-done
-
 if [ -z "${matched_registry}" ]; then
   cat << __VALIDATE_MATCH__
 ERROR: Could not find registry for ${PACKAGE_ID}

--- a/scripts/lib/variable/matched-registry.sh
+++ b/scripts/lib/variable/matched-registry.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+package_id_digits=${PACKAGE_ID//./ }
+domain_name=""
+matched_registry=""
+for digit in ${package_id_digits[@]}
+do
+  domain_name="${domain_name}.${digit}"
+  domain_name=$(echo ${domain_name} | sed -e 's/^\.//')
+  matched_registry=$(cat ${manifest_file} | jq ".scopedRegistries[] | select(.scopes[] == \"${domain_name}\")")
+  [[ -n "${matched_registry}" ]] && break
+done
+echo -n ""

--- a/scripts/lib/variable/version.sh
+++ b/scripts/lib/variable/version.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+if [ -z "${VERSION}"]; then
+  registry_url=$(echo ${matched_registry} | jq -r ".url")
+  package_info_url="${registry_url}/${PACKAGE_ID}"
+  VERSION=$(curl -s ${package_info_url} | jq -r ".\"dist-tags\".latest")
+fi
+
 [[ -n "${VERSION}" ]] || read -p "Version (ex: 1.2.3-preview.1): " VERSION

--- a/scripts/upm-add-package.sh
+++ b/scripts/upm-add-package.sh
@@ -9,6 +9,7 @@ package_json_file="Assets/package.json"
 
 source "${DIRECTORY}/scripts/lib/variable/package-id.sh"
 source "${DIRECTORY}/scripts/lib/validation/package-id.sh"
+source "${DIRECTORY}/scripts/lib/variable/matched-registry.sh"
 source "${DIRECTORY}/scripts/lib/validation/matched-registry.sh"
 
 source "${DIRECTORY}/scripts/lib/variable/version.sh"

--- a/scripts/upm-remove-package.sh
+++ b/scripts/upm-remove-package.sh
@@ -9,6 +9,7 @@ package_json_file="Assets/package.json"
 
 source "${DIRECTORY}/scripts/lib/variable/package-id.sh"
 source "${DIRECTORY}/scripts/lib/validation/package-id.sh"
+source "${DIRECTORY}/scripts/lib/variable/matched-registry.sh"
 source "${DIRECTORY}/scripts/lib/validation/matched-registry.sh"
 
 package_id=${PACKAGE_ID}


### PR DESCRIPTION
## Purpose

* Fixes #9 

## Plan

* Detect package version from package information that retrieved from registry API
* Skip version detection if version specified with command line arguments

## Implementation

No additional information.

## Test

* I don't write any test because this modification will dependent to external npm registry.
    * Consider providing a test-specific package in https://upm-package.dev

## Consultation

No consultation.